### PR TITLE
Add Performance Map sandbox feature

### DIFF
--- a/sandbox/performance-map/INTEGRATION.md
+++ b/sandbox/performance-map/INTEGRATION.md
@@ -1,0 +1,36 @@
+# Performance Map: Integration Guide
+
+## Overview
+This feature introduces a 2D world map showing where Shiori has performed. Integrate it into the `work` page to complement the existing performance grid.
+
+## Prerequisites
+- `framer-motion` is already installed.
+- Access to the `performances` data from `src/lib/data/performances`.
+
+## Integration Steps
+
+### Step 1: Convert Performances to Marker Data
+```typescript
+import { performances } from '@/lib/data/performances';
+import { toMapMarkers } from '@/sandbox/performance-map';
+
+const markers = toMapMarkers(performances);
+```
+
+### Step 2: Render the Map
+```tsx
+import PerformanceMap from '@/sandbox/performance-map';
+
+<PerformanceMap markers={markers} />
+```
+
+## Configuration Options
+`PerformanceMap` accepts `markers` that include latitude, longitude, label, and optional media.
+
+## Usage Examples
+Place the component above the performance list or on a dedicated page:
+```tsx
+<section className="mb-12">
+  <PerformanceMap markers={markers} />
+</section>
+```

--- a/sandbox/performance-map/README.md
+++ b/sandbox/performance-map/README.md
@@ -1,0 +1,5 @@
+# Performance Map
+
+Interactive 2D world map visualizing performance locations. This sandbox demonstrates a component that can be integrated into the main application.
+
+See `INTEGRATION.md` for integration steps.

--- a/sandbox/performance-map/REFLECTION.md
+++ b/sandbox/performance-map/REFLECTION.md
@@ -1,0 +1,17 @@
+# Performance Map: Implementation Reflection
+
+## Domain Insights
+Mapping performance locations visually helps highlight Shiori's international presence without overwhelming the existing layout.
+
+## Architecture Observations
+The project already uses React and `framer-motion`, making it straightforward to add hover animations without new dependencies.
+
+## Integration Considerations
+The map can be lazily loaded on pages to avoid adding weight to the initial bundle. Marker interactions can link to existing performance detail routes.
+
+## Enhancement Value
+This feature gives visitors a quick geographic overview of Shiori's performances while fitting naturally with the site's UI.
+
+## Next Steps
+- Replace the placeholder SVG with a more detailed map asset.
+- Add clustering or filtering when more locations are available.

--- a/sandbox/performance-map/SPEC.md
+++ b/sandbox/performance-map/SPEC.md
@@ -1,0 +1,28 @@
+# Performance Map: Technical Specification
+
+## Architecture Integration
+The component is implemented in React using plain SVG for the map and `framer-motion` for hover animations. It consumes the existing `performances` data and maps locations to 2D coordinates.
+
+## Components and Extensions
+
+### PerformanceMap
+- **Purpose**: Renders a simplified world map with pins for each performance location.
+- **Implementation Approach**: Uses an inline SVG for the map outline and absolute-positioned markers computed from latitude and longitude. Hovering a marker reveals a small card that fades in with `framer-motion`.
+- **Integration Points**: Can be imported into pages such as `src/app/work/page.tsx` to give users an overview of performance locations.
+
+### locationMap
+- **Purpose**: Provides a mapping from location strings in `performances.ts` to geographic coordinates.
+- **Implementation Approach**: Simple object lookup exported from the sandbox.
+- **Integration Points**: Used by `PerformanceMap` to place markers.
+
+## State and Data Flow
+The component receives an array of performances converted to marker objects. Internal state tracks which marker is active on hover to display the card. No external state management is required.
+
+## Integration Strategy
+1. Import `PerformanceMap` and the `performances` data.
+2. Convert the data to include coordinates using the `toMapMarkers` helper.
+3. Render the component where appropriate in the `work` page.
+
+## Future Considerations
+- Replace the placeholder SVG with a more detailed map.
+- Support filtering or clustering of markers as the number of performances grows.

--- a/sandbox/performance-map/VISION.md
+++ b/sandbox/performance-map/VISION.md
@@ -1,0 +1,23 @@
+# Performance Map: Vision & Rationale
+
+## The Enhancement
+A simple 2D world map displaying the cities where Shiori has performed. Hovering over a pin reveals a small card with a video or image and performance details.
+
+## Discovery Process
+The performances data already includes locations and media. A 2D map felt like a natural way to showcase these while fitting with the existing flat design of the site.
+
+## Alternative Approaches Considered
+
+### Alternative 1: 3D Globe
+- **Core Idea**: Render the locations on an interactive 3D globe.
+- **Potential Value**: Provides a striking visual effect.
+- **Why Not Selected**: Introduces heavier dependencies and felt out of place with the current UI.
+
+### Alternative 2: Timeline View
+- **Core Idea**: Display performances in chronological order along a timeline.
+- **Potential Value**: Emphasizes career progression.
+- **Why Not Selected**: Doesn't highlight the geographic spread.
+
+## Future Development Opportunities
+- Use a more detailed map asset for better visual accuracy.
+- Allow filtering or clustering of markers as the list grows.

--- a/sandbox/performance-map/src/PerformanceMap.tsx
+++ b/sandbox/performance-map/src/PerformanceMap.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export interface Marker {
+  lat: number;
+  lon: number;
+  label: string;
+  media?: { type: 'image' | 'video'; url: string };
+  artist?: string;
+  year?: string;
+}
+
+function latLonToXY(lat: number, lon: number, width: number, height: number) {
+  const x = ((lon + 180) / 360) * width;
+  const y = ((90 - lat) / 180) * height;
+  return { x, y };
+}
+
+export default function PerformanceMap({ markers }: { markers: Marker[] }) {
+  const width = 500;
+  const height = 250;
+  const [active, setActive] = useState<number | null>(null);
+
+  const continents = [
+    'M70 80 L160 80 L170 90 L150 120 L120 110 Z', // North America
+    'M170 110 L190 130 L180 180 L160 160 Z', // South America
+    'M280 80 L300 70 L320 90 L310 100 L290 95 Z', // Europe
+    'M300 100 L340 120 L330 160 L290 140 Z', // Africa
+    'M350 80 L390 90 L420 110 L410 140 L360 120 Z', // Asia
+    'M430 150 L450 160 L440 180 L420 170 Z', // Australia
+  ];
+
+  return (
+    <div className="relative" style={{ maxWidth: width }}>
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-auto">
+        <g fill="#2d2d2d">
+          {continents.map((d, i) => (
+            <path key={i} d={d} />
+          ))}
+        </g>
+      </svg>
+      {markers.map((m, i) => {
+        const { x, y } = latLonToXY(m.lat, m.lon, width, height);
+        return (
+          <div
+            key={i}
+            className="absolute"
+            style={{ left: x - 6, top: y - 6 }}
+            onMouseEnter={() => setActive(i)}
+            onMouseLeave={() => setActive(null)}
+          >
+            <div className="w-3 h-3 bg-pink-500 rounded-full shadow" />
+            <AnimatePresence>
+              {active === i && (
+                <motion.div
+                  initial={{ opacity: 0, y: -6 }}
+                  animate={{ opacity: 1, y: -10 }}
+                  exit={{ opacity: 0, y: -6 }}
+                  className="absolute left-4 top-0 bg-black text-white text-xs p-2 rounded w-40 z-10"
+                >
+                  <p className="font-bold mb-1">{m.label}</p>
+                  {m.artist && (
+                    <p className="mb-1">{m.artist} • {m.year}</p>
+                  )}
+                  {m.media && m.media.type === 'image' && (
+                    <img src={m.media.url} alt="media" className="w-full h-auto" />
+                  )}
+                  {m.media && m.media.type === 'video' && (
+                    <video src={m.media.url} className="w-full h-auto" controls />
+                  )}
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/sandbox/performance-map/src/index.ts
+++ b/sandbox/performance-map/src/index.ts
@@ -1,0 +1,14 @@
+export { default } from './PerformanceMap';
+export type { Marker } from './PerformanceMap';
+export { locationMap, coordsFor } from './locationMap';
+
+export function toMapMarkers(perfs: { location: string; title: string; artist: string; year: string; media: {type:'image'|'video'; url:string;}[] }) {
+  return perfs
+    .map((p) => {
+      const c = coordsFor(p.location);
+      if (!c) return undefined;
+      const media = p.media.find((m) => m.type === 'video') ?? p.media[0];
+      return { lat: c.lat, lon: c.lon, label: p.title, artist: p.artist, year: p.year, media };
+    })
+    .filter(Boolean) as Marker[];
+}

--- a/sandbox/performance-map/src/locationMap.ts
+++ b/sandbox/performance-map/src/locationMap.ts
@@ -1,0 +1,18 @@
+export interface LatLng {
+  lat: number;
+  lon: number;
+}
+
+// Approximate coordinates for locations appearing in performances.ts
+export const locationMap: Record<string, LatLng> = {
+  'Las Vegas, NV': { lat: 36.1699, lon: -115.1398 },
+  'Indio, CA': { lat: 33.6803, lon: -116.1739 },
+  'New York, NY': { lat: 40.7128, lon: -74.0060 },
+  'Asia': { lat: 1.3521, lon: 103.8198 },
+  'Japan': { lat: 35.6764, lon: 139.6500 },
+  'USA': { lat: 37.0902, lon: -95.7129 },
+};
+
+export function coordsFor(location: string): LatLng | undefined {
+  return locationMap[location];
+}

--- a/sandbox/performance-map/tests/locationMap.test.ts
+++ b/sandbox/performance-map/tests/locationMap.test.ts
@@ -1,0 +1,9 @@
+import { coordsFor } from '../src/locationMap';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('coordsFor returns coordinates for known location', () => {
+  const c = coordsFor('Las Vegas, NV');
+  assert.ok(c);
+  assert.equal(Math.round(c!.lat), 36);
+});


### PR DESCRIPTION
## Summary
- add Performance Map feature in sandbox
- document feature vision, spec, integration, and reflections
- provide map component and location mapping utilities
- include simple test for location mapping
- replace 3D globe with 2D map visualization

## Testing
- `node -v`
